### PR TITLE
LU-6635-backup-to-bucket

### DIFF
--- a/Blaise.Nuget.Api.Core/Interfaces/Services/IFileService.cs
+++ b/Blaise.Nuget.Api.Core/Interfaces/Services/IFileService.cs
@@ -8,5 +8,6 @@
 
         void BackupDatabaseFile(string dataFileName, string metaFileName, string destinationPath);
         void CopyFileToDirectory(string dataFileName, string destinationFilePath);
+        void CopyFileToGCloudBucket(string dataFileName, string destinationBucket);
     }
 }


### PR DESCRIPTION
Update `BackupDatabaseFile` to check if the destination string begins with "gs://"; if so, call the new `CopyFileToGCloudBucket` function which runs `gsutil` as an external process. Output from this process is not captured in logs.